### PR TITLE
Update vector.js

### DIFF
--- a/lib/vector.js
+++ b/lib/vector.js
@@ -120,7 +120,7 @@ function matrix2path(matrix) {
 function SVG(matrix, stream) {
     var N = matrix.length;
     var X = N + 2;
-    stream.push('<svg xmlns="http://www.w3.org/2000/svg" width="' + X + 'px" height="' + X + 'px" viewBox="0 0 ' + X + ' ' + X + '">');
+    stream.push('<svg xmlns="http://www.w3.org/2000/svg" width="' + X + '" height="' + X + '" viewBox="0 0 ' + X + ' ' + X + '">');
     stream.push('<path d="');
     matrix2path(matrix).forEach(function(subpath) {
         var res = '';


### PR DESCRIPTION
Added height and width to match viewBox.  Otherwise, when rendering page to PDF with wkhtmltopdf, generated SVG is missing if no height and width is set.
