### PR TITLE
I changed the way options are handled. Now you can produce QR codes with 0 margin.

### DIFF
--- a/lib/qr.js
+++ b/lib/qr.js
@@ -24,7 +24,7 @@ function qr_image(text, options) {
     }
     var _options = {};
     for (var k in DEFAULT_OPTIONS) {
-        _options[k] = options[k] || DEFAULT_OPTIONS[k];
+        _options[k] = k in options ? options[k] : DEFAULT_OPTIONS[k]; 
     }
     _options.type = ('' + _options.type).toLowerCase();
 


### PR DESCRIPTION
Hello. I found a little bug when I tried to produce a QR code without margin. I changed the code a little way to account for values that eval to false like 0.
