### PR TITLE
Update vector.js

### DIFF
--- a/lib/vector.js
+++ b/lib/vector.js
@@ -120,7 +120,7 @@ function matrix2path(matrix) {
 function SVG(matrix, stream) {
     var N = matrix.length;
     var X = N + 2;
-    stream.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + X + ' ' + X + '">');
+    stream.push('<svg xmlns="http://www.w3.org/2000/svg" width="' + X + '" height="' + X + '" viewBox="0 0 ' + X + ' ' + X + '" preserveAspectRatio="xMinYMin meet">');
     stream.push('<path d="');
     matrix2path(matrix).forEach(function(subpath) {
         var res = '';


### PR DESCRIPTION
I've been using SVG output extensively in a project and have come across a few tweaks:
1. Added height and width (unitless) - without these, wkhtmltopdf won't render them
2. Added preserveAspectRatio - without, Chrome won't scale inline <svg>
