### PR TITLE
add 'svgPath' as output option to lib/vector

### DIFF
--- a/lib/qr.js
+++ b/lib/qr.js
@@ -33,6 +33,7 @@ function qr_image(text, options) {
     stream._read = fn_noop;
 
     switch (_options.type) {
+    case 'svgPath':
     case 'svg':
     case 'pdf':
     case 'eps':

--- a/lib/vector.js
+++ b/lib/vector.js
@@ -117,11 +117,7 @@ function matrix2path(matrix) {
     }
 }
 
-function SVG(matrix, stream) {
-    var N = matrix.length;
-    var X = N + 2;
-    stream.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + X + ' ' + X + '">');
-    stream.push('<path d="');
+function SVGpath(matrix, stream) {
     matrix2path(matrix).forEach(function(subpath) {
         var res = '';
         for (var k = 0; k < subpath.length; k++) {
@@ -137,8 +133,16 @@ function SVG(matrix, stream) {
         res += 'z';
         stream.push(res);
     });
-    stream.push('"/></svg>');
-    stream.push(null);
+}
+
+function SVG(matrix, stream) {
+  var N = matrix.length;
+  var X = N + 2;
+  stream.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + X + ' ' + X + '">');
+  stream.push('<path d="');
+  SVGpath(matrix, stream);
+  stream.push('"/></svg>');
+  stream.push(null);
 }
 
 function EPS(matrix, stream) {
@@ -233,6 +237,7 @@ function PDF(matrix, stream) {
 }
 
 module.exports = {
+    svgPath: SVGpath,
     svg: SVG,
     eps: EPS,
     pdf: PDF


### PR DESCRIPTION
Very practical when working with other tools (pdfkit, d3) to make custom qr tags,
and better than using a regex to get the path from the SVG string ;)
