### PR TITLE
fixed svgPath option.

### DIFF
--- a/lib/qr.js
+++ b/lib/qr.js
@@ -33,7 +33,7 @@ function qr_image(text, options) {
     stream._read = fn_noop;
 
     switch (_options.type) {
-    case 'svgPath':
+    case 'svgpath':
     case 'svg':
     case 'pdf':
     case 'eps':

--- a/lib/vector.js
+++ b/lib/vector.js
@@ -117,7 +117,7 @@ function matrix2path(matrix) {
     }
 }
 
-function SVGpath(matrix, stream) {
+function pushSVGPath(matrix, stream) {
     matrix2path(matrix).forEach(function(subpath) {
         var res = '';
         for (var k = 0; k < subpath.length; k++) {
@@ -135,12 +135,17 @@ function SVGpath(matrix, stream) {
     });
 }
 
+function SVGpath(matrix, stream) {
+    pushSVGPath(matrix, stream);
+    stream.push(null);
+}
+
 function SVG(matrix, stream) {
   var N = matrix.length;
   var X = N + 2;
   stream.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + X + ' ' + X + '">');
   stream.push('<path d="');
-  SVGpath(matrix, stream);
+  pushSVGPath(matrix, stream);
   stream.push('"/></svg>');
   stream.push(null);
 }
@@ -237,7 +242,7 @@ function PDF(matrix, stream) {
 }
 
 module.exports = {
-    svgPath: SVGpath,
+    svgpath: SVGpath,
     svg: SVG,
     eps: EPS,
     pdf: PDF


### PR DESCRIPTION
#### Bugfixes:
- Option  `svgPath` was unreachable because of `('' + _options.type).toLowerCase()` and defaulted to `png` instead.
- Function `SVGPath` did not push `null` to stream before returning.
