### PR TITLE
Put crc32.js in an IIFE

### DIFF
--- a/lib/crc32.js
+++ b/lib/crc32.js
@@ -1,5 +1,7 @@
 "use strict";
 
+(function() {
+
 // ARMv6 (Raspberry Pi) has bug in bitwise operations
 // https://code.google.com/p/v8/issues/detail?id=3757
 // https://github.com/alexeyten/qr-image/issues/13
@@ -43,3 +45,5 @@ function crc32(/* arguments */) {
 }
 
 module.exports = crc32;
+    
+})();


### PR DESCRIPTION
This avoid a compile error (illegal return in the arm short-circuit)
when using from webpack.