### PR TITLE
use size as pixel for width/height instead a multiplicator

### DIFF
--- a/lib/vector.js
+++ b/lib/vector.js
@@ -151,8 +151,7 @@ function SVG(matrix, stream, margin, size) {
     var X = matrix.length + 2 * margin;
     stream.push('<svg xmlns="http://www.w3.org/2000/svg" ');
     if (size > 0) {
-        var XY = X * size;
-        stream.push('width="' + XY + '" height="' + XY + '" ');
+        stream.push('width="' + size + '" height="' + size + '" ');
     }
     stream.push('viewBox="0 0 ' + X + ' ' + X + '">');
     stream.push('<path d="');


### PR DESCRIPTION
size should be used for determining the size of the produced SVG instead of being a multiplier

as i understand the documentation it should work like my implementation:

> size (png and svg only) — size of one module in pixels. Default 5 for png and undefined for svg.