### PR TITLE
Splits each method in its own file, remove Buffer as a hard dependency

### DIFF
--- a/lib/crc32.js
+++ b/lib/crc32.js
@@ -38,7 +38,7 @@ function crc32(/* arguments */) {
     var l = arguments.length;
     var c = -1;
     for (var i = 0; i < l; i++) {
-        c = update(c, new Uint8Array(arguments[i]));
+        c = update(c, Uint8Array.from(arguments[i]));
     }
     c = (c ^ -1) >>> 0;
     return c;

--- a/lib/crc32.js
+++ b/lib/crc32.js
@@ -38,7 +38,7 @@ function crc32(/* arguments */) {
     var l = arguments.length;
     var c = -1;
     for (var i = 0; i < l; i++) {
-        c = update(c, new Buffer(arguments[i]));
+        c = update(c, new Uint8Array(arguments[i]));
     }
     c = (c ^ -1) >>> 0;
     return c;

--- a/lib/crc32buffer.js
+++ b/lib/crc32buffer.js
@@ -36,7 +36,7 @@ function crc32(/* arguments */) {
     c.fill(0xff);
 
     for (var i = 0; i < l; i++) {
-        update(c, new Uint8Array(arguments[i]));
+        update(c, Uint8Array.from(arguments[i]));
     }
 
     c[0] = c[0] ^ 0xff;

--- a/lib/crc32buffer.js
+++ b/lib/crc32buffer.js
@@ -3,7 +3,7 @@
 var crc_table = [];
 
 for (var n = 0; n < 256; n++) {
-    var c = crc_table[n] = new Buffer(4);
+    var c = crc_table[n] = new Uint8Array(4);
     c.writeUInt32BE(n, 0);
 
     for (var k = 0; k < 8; k++) {
@@ -32,11 +32,11 @@ function update(c, buf) {
 
 function crc32(/* arguments */) {
     var l = arguments.length;
-    var c = new Buffer(4);
+    var c = new Uint8Array(4);
     c.fill(0xff);
 
     for (var i = 0; i < l; i++) {
-        update(c, new Buffer(arguments[i]));
+        update(c, new Uint8Array(arguments[i]));
     }
 
     c[0] = c[0] ^ 0xff;

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -137,11 +137,11 @@ function encode(data, parse_url) {
 
     if (t == 'string' || t == 'number') {
         str = '' + data;
-        data = new Buffer(str);
-    } else if (Buffer.isBuffer(data)) {
+        data = new Uint8Array(str);
+    } else if ((typeof Buffer !== "undefined") && (Buffer.isBuffer(data))) {
         str = data.toString();
     } else if (Array.isArray(data)) {
-        data = new Buffer(data);
+        data = new Uint8Array(data);
         str = data.toString();
     } else {
         throw new Error("Bad data");

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -137,11 +137,11 @@ function encode(data, parse_url) {
 
     if (t == 'string' || t == 'number') {
         str = '' + data;
-        data = new Uint8Array(str);
+        data = Uint8Array.from(str);
     } else if ((typeof Buffer !== "undefined") && (Buffer.isBuffer(data))) {
         str = data.toString();
     } else if (Array.isArray(data)) {
-        data = new Uint8Array(data);
+        data = Uint8Array.from(data);
         str = data.toString();
     } else {
         throw new Error("Bad data");

--- a/lib/errorcode.js
+++ b/lib/errorcode.js
@@ -73,5 +73,5 @@ module.exports = function calculate_ec(msg, ec_len) {
         }
         msg.shift();
     }
-    return new Buffer(msg);
+    return new Uint8Array(msg);
 }

--- a/lib/errorcode.js
+++ b/lib/errorcode.js
@@ -73,5 +73,5 @@ module.exports = function calculate_ec(msg, ec_len) {
         }
         msg.shift();
     }
-    return new Uint8Array(msg);
+    return Uint8Array.from(msg);
 }

--- a/lib/image-sync.js
+++ b/lib/image-sync.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var QR = require('./qr-base').QR;
+var png = require('./png');
+var vector = require('./vector');
+var get_options = require('./options');
+
+function qr_image_sync(text, options) {
+    options = get_options(options);
+
+    var matrix = QR(text, options.ec_level, options.parse_url);
+    var stream = [];
+    var result;
+
+    switch (options.type) {
+    case 'svg':
+    case 'pdf':
+    case 'eps':
+        vector[options.type](matrix, stream, options.margin, options.size);
+        result = stream.filter(Boolean).join('');
+        break;
+    case 'png':
+    default:
+        var bitmap = png.bitmap(matrix, options.size, options.margin);
+        if (options.customize) {
+            options.customize(bitmap);
+        }
+        png.png(bitmap, stream);
+        result = Buffer.concat(stream.filter(Boolean));
+    }
+
+    return result;
+}
+
+module.exports = qr_image_sync;

--- a/lib/image-sync.js
+++ b/lib/image-sync.js
@@ -26,7 +26,7 @@ function qr_image_sync(text, options) {
             options.customize(bitmap);
         }
         png.png(bitmap, stream);
-        result = Buffer.concat(stream.filter(Boolean));
+        result = Uint8Array.concat(stream.filter(Boolean));
     }
 
     return result;

--- a/lib/image.js
+++ b/lib/image.js
@@ -1,0 +1,49 @@
+"use strict";
+
+var Readable = require('stream').Readable;
+
+var QR = require('./qr-base').QR;
+var png = require('./png');
+var vector = require('./vector');
+var get_options = require('./options');
+
+var fn_noop = function() {};
+
+function qr_image(text, options) {
+    options = get_options(options);
+
+    var matrix = QR(text, options.ec_level, options.parse_url);
+    var stream = new Readable();
+    stream._read = fn_noop;
+
+    switch (options.type) {
+    case 'svg':
+    case 'pdf':
+    case 'eps':
+        process.nextTick(function() {
+            vector[options.type](matrix, stream, options.margin, options.size);
+        });
+        break;
+    case 'svgpath':
+        // deprecated, use svg_object method
+        process.nextTick(function() {
+            var obj = vector.svg_object(matrix, options.margin, options.size);
+            stream.push(obj.path);
+            stream.push(null);
+        });
+        break;
+    case 'png':
+    default:
+        process.nextTick(function() {
+            var bitmap = png.bitmap(matrix, options.size, options.margin);
+            if (options.customize) {
+                options.customize(bitmap);
+            }
+            png.png(bitmap, stream);
+        });
+    }
+
+    return stream;
+}
+
+module.exports = qr_image;

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -4,7 +4,7 @@
 function init(version) {
     var N = version * 4 + 17;
     var matrix = [];
-    var zeros = new Buffer(N);
+    var zeros = new Uint8Array(N);
     zeros.fill(0);
     zeros = [].slice.call(zeros);
     for (var i = 0; i < N; i++) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,0 +1,37 @@
+"use strict";
+
+var BITMAP_OPTIONS = {
+    parse_url: false,
+    ec_level: 'M',
+    size: 5,
+    margin: 4,
+    customize: null
+};
+
+var VECTOR_OPTIONS = {
+    parse_url: false,
+    ec_level: 'M',
+    margin: 1,
+    size: 0
+};
+
+function get_options(options, force_type) {
+    if (typeof options === 'string') {
+        options = { 'ec_level': options }
+    } else {
+        options = options || {};
+    }
+    var _options = {
+        type: String(force_type || options.type || 'png').toLowerCase()
+    };
+
+    var defaults = _options.type == 'png' ? BITMAP_OPTIONS : VECTOR_OPTIONS;
+
+    for (var k in defaults) {
+        _options[k] = k in options ? options[k] : defaults[k];
+    }
+
+    return _options;
+}
+
+module.exports = get_options;

--- a/lib/png.js
+++ b/lib/png.js
@@ -4,24 +4,24 @@ var zlib = require('zlib');
 
 var crc32 = require('./crc32');
 
-var PNG_HEAD = new Buffer([137,80,78,71,13,10,26,10]);
-var PNG_IHDR = new Buffer([0,0,0,13,73,72,68,82,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0]);
-var PNG_IDAT = new Buffer([0,0,0,0,73,68,65,84]);
-var PNG_IEND = new Buffer([0,0,0,0,73,69,78,68,174,66,96,130]);
+var PNG_HEAD = new Uint8Array([137,80,78,71,13,10,26,10]);
+var PNG_IHDR = new Uint8Array([0,0,0,13,73,72,68,82,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0]);
+var PNG_IDAT = new Uint8Array([0,0,0,0,73,68,65,84]);
+var PNG_IEND = new Uint8Array([0,0,0,0,73,69,78,68,174,66,96,130]);
 
 function png(bitmap, stream) {
     stream.push(PNG_HEAD);
 
-    var IHDR = Buffer.concat([PNG_IHDR]);
+    var IHDR = Uint8Array.concat([PNG_IHDR]);
     IHDR.writeUInt32BE(bitmap.size, 8);
     IHDR.writeUInt32BE(bitmap.size, 12);
     IHDR.writeUInt32BE(crc32(IHDR.slice(4, -4)), 21);
     stream.push(IHDR);
 
-    var IDAT = Buffer.concat([
+    var IDAT = Uint8Array.concat([
         PNG_IDAT,
         zlib.deflateSync(bitmap.data, { level: 9 }),
-        new Buffer(4)
+        new Uint8Array(4)
     ]);
     IDAT.writeUInt32BE(IDAT.length - 12, 0);
     IDAT.writeUInt32BE(crc32(IDAT.slice(4, -4)), IDAT.length - 4);
@@ -34,7 +34,7 @@ function png(bitmap, stream) {
 function bitmap(matrix, size, margin) {
     var N = matrix.length;
     var X = (N + 2 * margin) * size;
-    var data = new Buffer((X + 1) * X);
+    var data = new Uint8Array((X + 1) * X);
     data.fill(255);
     for (var i = 0; i < X; i++) {
         data[i * (X + 1)] = 0;

--- a/lib/png.js
+++ b/lib/png.js
@@ -4,10 +4,10 @@ var zlib = require('zlib');
 
 var crc32 = require('./crc32');
 
-var PNG_HEAD = new Uint8Array([137,80,78,71,13,10,26,10]);
-var PNG_IHDR = new Uint8Array([0,0,0,13,73,72,68,82,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0]);
-var PNG_IDAT = new Uint8Array([0,0,0,0,73,68,65,84]);
-var PNG_IEND = new Uint8Array([0,0,0,0,73,69,78,68,174,66,96,130]);
+var PNG_HEAD = Uint8Array.from([137,80,78,71,13,10,26,10]);
+var PNG_IHDR = Uint8Array.from([0,0,0,13,73,72,68,82,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0]);
+var PNG_IDAT = Uint8Array.from([0,0,0,0,73,68,65,84]);
+var PNG_IEND = Uint8Array.from([0,0,0,0,73,69,78,68,174,66,96,130]);
 
 function png(bitmap, stream) {
     stream.push(PNG_HEAD);

--- a/lib/qr-base.js
+++ b/lib/qr-base.js
@@ -126,7 +126,7 @@ function getTemplate(message, ec_level) {
 
 // {{{1 Fill template
 function fillTemplate(message, template) {
-    var blocks = new Buffer(template.data_len);
+    var blocks = new Uint8Array(template.data_len);
     blocks.fill(0);
 
     if (template.version < 10) {

--- a/lib/qr.js
+++ b/lib/qr.js
@@ -1,117 +1,12 @@
 "use strict";
 
-var Readable = require('stream').Readable;
-
 var QR = require('./qr-base').QR;
 var png = require('./png');
 var vector = require('./vector');
-
-var fn_noop = function() {};
-
-var BITMAP_OPTIONS = {
-    parse_url: false,
-    ec_level: 'M',
-    size: 5,
-    margin: 4,
-    customize: null
-};
-
-var VECTOR_OPTIONS = {
-    parse_url: false,
-    ec_level: 'M',
-    margin: 1,
-    size: 0
-};
-
-function get_options(options, force_type) {
-    if (typeof options === 'string') {
-        options = { 'ec_level': options }
-    } else {
-        options = options || {};
-    }
-    var _options = {
-        type: String(force_type || options.type || 'png').toLowerCase()
-    };
-
-    var defaults = _options.type == 'png' ? BITMAP_OPTIONS : VECTOR_OPTIONS;
-
-    for (var k in defaults) {
-        _options[k] = k in options ? options[k] : defaults[k];
-    }
-
-    return _options;
-}
-
-function qr_image(text, options) {
-    options = get_options(options);
-
-    var matrix = QR(text, options.ec_level, options.parse_url);
-    var stream = new Readable();
-    stream._read = fn_noop;
-
-    switch (options.type) {
-    case 'svg':
-    case 'pdf':
-    case 'eps':
-        process.nextTick(function() {
-            vector[options.type](matrix, stream, options.margin, options.size);
-        });
-        break;
-    case 'svgpath':
-        // deprecated, use svg_object method
-        process.nextTick(function() {
-            var obj = vector.svg_object(matrix, options.margin, options.size);
-            stream.push(obj.path);
-            stream.push(null);
-        });
-        break;
-    case 'png':
-    default:
-        process.nextTick(function() {
-            var bitmap = png.bitmap(matrix, options.size, options.margin);
-            if (options.customize) {
-                options.customize(bitmap);
-            }
-            png.png(bitmap, stream);
-        });
-    }
-
-    return stream;
-}
-
-function qr_image_sync(text, options) {
-    options = get_options(options);
-
-    var matrix = QR(text, options.ec_level, options.parse_url);
-    var stream = [];
-    var result;
-
-    switch (options.type) {
-    case 'svg':
-    case 'pdf':
-    case 'eps':
-        vector[options.type](matrix, stream, options.margin, options.size);
-        result = stream.filter(Boolean).join('');
-        break;
-    case 'png':
-    default:
-        var bitmap = png.bitmap(matrix, options.size, options.margin);
-        if (options.customize) {
-            options.customize(bitmap);
-        }
-        png.png(bitmap, stream);
-        result = Buffer.concat(stream.filter(Boolean));
-    }
-
-    return result;
-}
-
-function svg_object(text, options) {
-    options = get_options(options, 'svg');
-
-    var matrix = QR(text, options.ec_level);
-    return vector.svg_object(matrix, options.margin);
-}
+var get_options = require('./options');
+var qr_image = require('./image');
+var qr_image_sync = require('./image-sync');
+var svg_object = require('./svg-object');
 
 module.exports = {
     matrix: QR,

--- a/lib/svg-object.js
+++ b/lib/svg-object.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var QR = require('./qr-base').QR;
+var vector = require('./vector');
+var get_options = require('./options');
+
+function svg_object(text, options) {
+    options = get_options(options, 'svg');
+
+    var matrix = QR(text, options.ec_level);
+    return vector.svg_object(matrix, options.margin);
+}
+
+module.exports = svg_object;


### PR DESCRIPTION
With this small set of backward compatible changes it becomes possible to create a browser standalone version of svg_object packing the following snippet of code with webpack

`window.svg_object = require('qr-image/lib/svg-object');
`